### PR TITLE
Use jq `--raw-output,-r` option instead of piping through `sed`

### DIFF
--- a/sendTeamsNotification.sh
+++ b/sendTeamsNotification.sh
@@ -5,9 +5,9 @@ webhook="YOUR MS TEAMS WEBHOOK"
 kapacitorInfos="$(< /dev/stdin)"
 
 # Extract fields
-details=$(echo $kapacitorInfos | jq .details | sed 's/\"//g')
-title=$(echo $kapacitorInfos | jq .message | sed 's/\"//g')
-level=$(echo $kapacitorInfos | jq .level | sed 's/\"//g')
+details=$(echo $kapacitorInfos | jq .details -r)
+title=$(echo $kapacitorInfos | jq .message -r)
+level=$(echo $kapacitorInfos | jq .level -r)
 
 # Get the correct color for MS Teams
 case "$level" in


### PR DESCRIPTION
As a message may also contain new lines `\n`, it would require adding more replace operations to `sed`.

Instead, `jq` has the `--raw-output, -r` parameter that will output a raw string that does not escape control characters and does not include '"'

https://stedolan.github.io/jq/manual/